### PR TITLE
Prevent concurrent migration executions

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -14,8 +14,10 @@ type Migration struct {
 
 // Client is a migration database connection.
 type Client struct {
-	conn    *pgx.Conn
-	ensured bool
+	conn         *pgx.Conn
+	databaseName string
+	locked       bool
+	ensured      bool
 }
 
 // Connect connects to the Postgres database at the given uri.
@@ -28,7 +30,11 @@ func Connect(uri string) (*Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to database")
 	}
-	return &Client{conn: conn}, nil
+	c := &Client{
+		conn:         conn,
+		databaseName: cfg.Database,
+	}
+	return c, nil
 }
 
 // Close closes the underlying database connection.

--- a/db/lock.go
+++ b/db/lock.go
@@ -1,0 +1,39 @@
+package db
+
+import "hash/fnv"
+
+func generateAdvisoryLockID(database string) int {
+	h := fnv.New32a()
+	h.Write([]byte(database))
+	h.Write([]byte("migrate"))
+	return int(h.Sum32())
+}
+
+// TryLock attempts to acquire an exclusive lock for running migrations
+// on this database.
+func (c *Client) TryLock() (bool, error) {
+	id := generateAdvisoryLockID(c.databaseName)
+	var success bool
+	err := c.conn.QueryRow(`select pg_try_advisory_lock($1);`, id).Scan(&success)
+	if err != nil {
+		return false, err
+	}
+	if success {
+		c.locked = true
+	}
+	return success, nil
+}
+
+// Unlock unlocks the exclusive migration lock.
+func (c *Client) Unlock() (bool, error) {
+	id := generateAdvisoryLockID(c.databaseName)
+	var success bool
+	err := c.conn.QueryRow(`select pg_advisory_unlock($1);`, id).Scan(&success)
+	if err != nil {
+		return false, err
+	}
+	if success {
+		c.locked = false
+	}
+	return success, nil
+}


### PR DESCRIPTION
migrate now acquires an exclusive lock (via `pg_try_advisory_lock`)
before running migrations, preventing migrations from accidentally being
applied in parallel.

Addresses #4.